### PR TITLE
fix YaST homepage url

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
               </a>
             </div>
             <div class="media-body">
-              <a href="https://en.opensuse.org/Portal:YaST" target="_blank">
+              <a href="http://yast.github.io/" target="_blank">
                 <h4 class="media-heading opensuse-blue strong-title">
                   YaST
                   <small>


### PR DESCRIPTION
The link is different for the "go to..." link and points to the old wiki page