### PR TITLE
Improve landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,20 +81,6 @@
     <article class="container-fluid">
       <h3 class="text-center wow fadeInUp" lang="en">The makers' choice for sysadmins, developers and desktop users.</h3>
       <div class="row os-main">
-        <div class="col-sm-6 text-center wow fadeIn" data-wow-delay=".2s">
-          <div id="tumbleweed">
-            <div class="distributions-icon">
-              <img src="assets/images/tumbleweed-icon.svg" class="wow bounceInDown"  data-wow-delay=".7s" />
-            </div>
-            <h1 class="wow fadeIn" data-wow-delay=".5s">Tumbleweed</h1>
-            <h4 class="wow fadeIn" data-wow-delay=".6s" lang="en">Get the newest Linux packages with our rolling release. Fast! Integrated! Stabilized! Tested!</h4>
-            <p class="moreinfo btn btn-primary" lang="en">More information</p>
-            <div class="hidden-content">
-              <p lang="en">Any user who wishes to have the newest packages that include, but are not limited to, the Linux kernel, SAMBA, git, desktops, office applications and many other packages, will want Tumbleweed. Tumbleweed appeals to Power Users, Software Developers and openSUSE Contributors. If you require the latest software stacks and Integrated Development Environment or need a stable platform closest to bleeding edge Linux, Tumbleweed is the best choice for you.</p>
-              <a href="https://en.opensuse.org/openSUSE:Tumbleweed_installation" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Install Tumbleweed</span></a>
-            </div>
-          </div>
-        </div>
         <div class="col-sm-6 text-center">
           <div id="openSUSE">
             <div class="distributions-icon">
@@ -106,6 +92,20 @@
             <div class="hidden-content">
               <p lang="en">New and experienced Linux users get the most usable Linux distribution and stabilized operating system with openSUSE’s regular release. Receive updates and harden your OS with openSUSE’s latest major distribution. Pick your desktop, configure your system and enjoy the platform of choice for Linux developers, administrators and software vendors.</p>
               <a href="https://software.opensuse.org/132/en" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Install openSUSE</span></a>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-6 text-center wow fadeIn" data-wow-delay=".2s">
+          <div id="tumbleweed">
+            <div class="distributions-icon">
+              <img src="assets/images/tumbleweed-icon.svg" class="wow bounceInDown"  data-wow-delay=".7s" />
+            </div>
+            <h1 class="wow fadeIn" data-wow-delay=".5s">Tumbleweed</h1>
+            <h4 class="wow fadeIn" data-wow-delay=".6s" lang="en">Get the newest Linux packages with our rolling release. Fast! Integrated! Stabilized! Tested!</h4>
+            <p class="moreinfo btn btn-primary" lang="en">More information</p>
+            <div class="hidden-content">
+              <p lang="en">Any user who wishes to have the newest packages that include, but are not limited to, the Linux kernel, SAMBA, git, desktops, office applications and many other packages, will want Tumbleweed. Tumbleweed appeals to Power Users, Software Developers and openSUSE Contributors. If you require the latest software stacks and Integrated Development Environment or need a stable platform closest to bleeding edge Linux, Tumbleweed is the best choice for you.</p>
+              <a href="https://en.opensuse.org/openSUSE:Tumbleweed_installation" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Install Tumbleweed</span></a>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -52,9 +52,6 @@
               <a class='smoothScroll' data-linkto='opensuse-tools' href="#"><span lang="en">Tools</span></a>
             </li>
             <li>
-              <a class='smoothScroll' data-linkto='new-tools' href="#"><span lang="en">What's new</span></a>
-            </li>
-            <li>
               <a class='smoothScroll' data-linkto='news' href="#"><span lang="en">News</span></a>
             </li>
             <li>
@@ -198,6 +195,24 @@
               <p lang="en">Create Linux images for deployment on real hardware, virtualisation, and now even container systems like Docker. Kiwi is the engine that powers SUSE Studio.</p>
             </div>
           </div>
+          <div class="media wow slideInLeft">
+            <div class="media-left">
+              <a href="http://machinery-project.org/" target="_blank">
+                <img class="media-object" src="assets/images/tools/yast.svg" alt="Machinery">
+              </a>
+            </div>
+            <div class="media-body">
+              <a href="http://machinery-project.org/" target="_blank">
+                <h4 class="media-heading opensuse-blue strong-title">
+                  Machinery
+                  <small>
+                    (<span lang="en">Go to link</span> <i class="fa fa-external-link"></i> )
+                  </small>
+                </h4>
+              </a>
+              <p lang="en">A systems management toolkit for Linux. Machinery supports configuration discovery, system validation, and service migration.</p>
+            </div>
+          </div>
         </div>
         <div class="col-md-6 tools-laptop">
           <div class="wow slideInUp text-right hidden-sm">
@@ -213,23 +228,6 @@
 
   <div class="gray-triangular-division wow slideInDown"></div>
 
-  <section id="new-tools">
-    <article class="container-fluid">
-      <div class="row">
-        <div class="col-sm-5 to-try-out-img wow fadeInLeft">
-          <img src="assets/images/new-tools-to-try-out.svg" />
-        </div>
-        <div class="col-sm-5 col-sm-offset-2 wow fadeInRight">
-          <h2 class="opensuse-blue strong-title">Machinery</h2>
-          <p class="opensuse-blue"><span lang="en">Machinery supports configuration discovery, system validation, and service migration.</span><br><span lang="en">Machinery is based on the idea of an universal system description. It is transparent, extensible, and crafted beautifully. </span><br><span lang="en">Machinery is made for the system administrator of the data center. Read more about the philosophy behind it.</span></p>
-          <a href="http://machinery-project.org/" target="_blank">
-            <span lang="en">More information</span>
-            <i class="fa fa-caret-right"></i>
-          </a>
-        </div>
-      </div>
-    </article>
-  </section>
   <section id="news">
     <article class="container-fluid">
       <div class="title-line wow zoomIn">

--- a/index.html
+++ b/index.html
@@ -94,7 +94,8 @@
             </a>
             <div class="hidden-content">
               <p lang="en">New and experienced Linux users get the most usable Linux distribution and stabilized operating system with openSUSE’s regular release. Receive updates and harden your OS with openSUSE’s latest major distribution. Pick your desktop, configure your system and enjoy the platform of choice for Linux developers, administrators and software vendors.</p>
-              <a href="https://software.opensuse.org/132/en" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Install openSUSE</span></a>
+              <a href="https://software.opensuse.org/132/en" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Install openSUSE 13.2</span></a>
+              <a href="https://en.opensuse.org/Portal:Leap" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Learn more</span></a>
             </div>
           </div>
         </div>
@@ -112,6 +113,7 @@
             <div class="hidden-content">
               <p lang="en">Any user who wishes to have the newest packages that include, but are not limited to, the Linux kernel, SAMBA, git, desktops, office applications and many other packages, will want Tumbleweed. Tumbleweed appeals to Power Users, Software Developers and openSUSE Contributors. If you require the latest software stacks and Integrated Development Environment or need a stable platform closest to bleeding edge Linux, Tumbleweed is the best choice for you.</p>
               <a href="https://en.opensuse.org/openSUSE:Tumbleweed_installation" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Install Tumbleweed</span></a>
+              <a href="https://en.opensuse.org/Portal:Tumbleweed" target="_blank" class="btn btn-primary"><span lang="en">Learn more</span></a>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -179,12 +179,12 @@
           </div>
           <div class="media wow slideInLeft">
             <div class="media-left">
-              <a href="http://opensuse.github.io/kiwi/ " target="_blank">
+              <a href="http://opensuse.github.io/kiwi/" target="_blank">
                 <img class="media-object" src="assets/images/tools/kiwi.svg" alt="Kiwi">
               </a>
             </div>
             <div class="media-body">
-              <a href="https://doc.opensuse.org/projects/kiwi/doc/#sec.introduction.whatiskiwi " target="_blank">
+              <a href="http://opensuse.github.io/kiwi/" target="_blank">
                 <h4 class="media-heading opensuse-blue strong-title">
                   Kiwi
                   <small>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,9 @@
             <h1 class="wow fadeIn" data-wow-delay=".5s">Leap</h1>
             <h4 class="wow fadeIn" data-wow-delay=".6s" lang="en">Get the most complete Linux distribution with openSUSE’s latest regular-release version!</h4>
             <p class="moreinfo btn btn-primary" lang="en">More information</p>
+            <a href="https://software.opensuse.org/132/">
+              <p class="moreinfo btn btn-primary" lang="en">Install 13.2</p>
+            </a>
             <div class="hidden-content">
               <p lang="en">New and experienced Linux users get the most usable Linux distribution and stabilized operating system with openSUSE’s regular release. Receive updates and harden your OS with openSUSE’s latest major distribution. Pick your desktop, configure your system and enjoy the platform of choice for Linux developers, administrators and software vendors.</p>
               <a href="https://software.opensuse.org/132/en" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Install openSUSE</span></a>
@@ -103,6 +106,9 @@
             <h1 class="wow fadeIn" data-wow-delay=".5s">Tumbleweed</h1>
             <h4 class="wow fadeIn" data-wow-delay=".6s" lang="en">Get the newest Linux packages with our rolling release. Fast! Integrated! Stabilized! Tested!</h4>
             <p class="moreinfo btn btn-primary" lang="en">More information</p>
+            <a href="https://en.opensuse.org/openSUSE:Tumbleweed_installation">
+              <p class="moreinfo btn btn-primary" lang="en">Install</p>
+            </a>
             <div class="hidden-content">
               <p lang="en">Any user who wishes to have the newest packages that include, but are not limited to, the Linux kernel, SAMBA, git, desktops, office applications and many other packages, will want Tumbleweed. Tumbleweed appeals to Power Users, Software Developers and openSUSE Contributors. If you require the latest software stacks and Integrated Development Environment or need a stable platform closest to bleeding edge Linux, Tumbleweed is the best choice for you.</p>
               <a href="https://en.opensuse.org/openSUSE:Tumbleweed_installation" target="_blank" class="btn btn-primary"><i class="fa fa-download"></i> <span lang="en">Install Tumbleweed</span></a>


### PR DESCRIPTION
Firstly I want to say - awesome work!  I love this new design which IMHO looks quite a lot more professional and appealing than the old one, and is quite close to perfect :-)  I just noticed a few minor things which I have tried to address with this pull request.

Firstly I wonder if it is maybe slightly too early to drop the mentions of the pre-Leap releases (13.2 etc.) from the main page.  A lot of people won't have heard of Leap yet, so there are some user stories which could maybe be addressed a bit better here:

1. As a total newbie to openSUSE who got recommended to try out openSUSE, I want to learn in more detail the difference between Leap and Tumbleweed and 13.2.
2. As a total newbie to openSUSE who got recommended to try out openSUSE, I want to learn how to download and install Leap 
3. As a total newbie to openSUSE who got recommended to try out 13.2, I want to learn how to download and install 13.2.
4. As a non-newbie, I want to quickly download and install 13.2 or Leap or Tumbleweed

Hopefully the changes are obvious from the commit messages.