### PR TITLE
Use navigator language as default if available

### DIFF
--- a/assets/js/opensuse-theme.js
+++ b/assets/js/opensuse-theme.js
@@ -247,22 +247,37 @@ $(document).on("click", ".change-language", function() {
 //check if there is a langCookie in the browser
 $(document).on("ready", function(){
 
+  var languageCode;
   var selectedLanguageName;
 
   if (cookieLanguage === undefined) {
     try {
-      window.lang.change(navigator.language);
-      selectedLanguageName = $(".languages").find("[data-language-value='" + navigator.language + "']").html();
+      // try to use navigator.language
+      languageCode = navigator.language.replace("-","_");
+      window.lang.change(languageCode);
     }
     catch(err) {
-      // navigator.language not available, falling back to default
-      selectedLanguageName = "English";
+      // navigator.language is not available
+      if (navigator.language.length > 2) {
+        try {
+          // try with a more general string (for example, if navigator.language is "es-ES" then "es" is tried)
+          languageCode = navigator.language.substring(0,2);
+          window.lang.change(languageCode);
+        }
+        catch(err) {
+          languageCode = "en";
+        }
+      }
+      else {
+        languageCode = "en";
+      }
     }
   }
   else {
-    selectedLanguageName = $(".languages").find("[data-language-value='" + cookieLanguage + "']").html();
+    languageCode = cookieLanguage;
   }
 
+  selectedLanguageName = $(".languages").find("[data-language-value='" + languageCode + "']").html();
   $(".selected-language").html(selectedLanguageName);
 
 });

--- a/assets/js/opensuse-theme.js
+++ b/assets/js/opensuse-theme.js
@@ -246,10 +246,24 @@ $(document).on("click", ".change-language", function() {
 
 //check if there is a langCookie in the browser
 $(document).on("ready", function(){
-  if(cookieLanguage != "") {
-    var selectedLanguageName = $(".languages").find("[data-language-value='"+ cookieLanguage+"']").html()
-    $(".selected-language").html(selectedLanguageName);
+
+  var selectedLanguageName;
+
+  if (cookieLanguage === undefined) {
+    try {
+      window.lang.change(navigator.language);
+      selectedLanguageName = $(".languages").find("[data-language-value='" + navigator.language + "']").html();
+    }
+    catch(err) {
+      // navigator.language not available, falling back to default
+      selectedLanguageName = "English";
+    }
   }
+  else {
+    selectedLanguageName = $(".languages").find("[data-language-value='" + cookieLanguage + "']").html();
+  }
+
+  $(".selected-language").html(selectedLanguageName);
 
 });
 //*****************


### PR DESCRIPTION
It will try to use navigator.language if no cookieLanguage is set.
If the navigator language is not available, falling back to English.